### PR TITLE
Don't require final / for HTML void elements

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -3,6 +3,7 @@ require 'htmlbeautifier/parser'
 module HtmlBeautifier
   class HtmlParser < Parser
     ELEMENT_CONTENT = %r{ (?:[^<>]|<%.*?%>)* }mx
+    HTML_VOID_ELEMENTS = %w[area base br col command embed hr img input keygen link meta param source track wbr].join("|")
 
     def initialize
       super do |p|
@@ -14,6 +15,7 @@ module HtmlBeautifier
         p.map %r{(<script#{ELEMENT_CONTENT}>)(.*?)(</script>)}m,  :foreign_block
         p.map %r{(<style#{ELEMENT_CONTENT}>)(.*?)(</style>)}m,    :foreign_block
         p.map %r{<#{ELEMENT_CONTENT}/>}m,                         :standalone_element
+        p.map %r{(<(?i:#{HTML_VOID_ELEMENTS})#{ELEMENT_CONTENT}>)}m, :standalone_element
         p.map %r{</#{ELEMENT_CONTENT}>}m,                         :close_element
         p.map %r{<#{ELEMENT_CONTENT}>}m,                          :open_element
         p.map %r{\s+},                                            :whitespace

--- a/test/test_html_beautifier_regression.rb
+++ b/test/test_html_beautifier_regression.rb
@@ -248,4 +248,13 @@ class HtmlBeautifierRegressionTest < Test::Unit::TestCase
     assert_beautifies source, source
   end
 
+  def test_should_not_indent_html_void_elements
+    source = code(%q(
+    <meta>
+    <input id="id">
+    <br>
+    ))
+    assert_beautifies source, source
+  end
+
 end


### PR DESCRIPTION
Don't indent non-XHTML style self-closing/void elements such as

```
<meta>
<input>
<br>
```

List of void elements is from http://www.w3.org/TR/html-markup/syntax.html#syntax-elements
