### PR TITLE
Fix matching of void elements to always match full tag name

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -26,7 +26,7 @@ module HtmlBeautifier
           :foreign_block
         p.map %r{<#{ELEMENT_CONTENT}/>}m,
           :standalone_element
-        p.map %r{<#{HTML_VOID_ELEMENTS}#{ELEMENT_CONTENT}>}m,
+        p.map %r{<#{HTML_VOID_ELEMENTS}(?: #{ELEMENT_CONTENT})?>}m,
           :standalone_element
         p.map %r{</#{ELEMENT_CONTENT}>}m,
           :close_element

--- a/test/test_html_beautifier_integration.rb
+++ b/test/test_html_beautifier_integration.rb
@@ -38,6 +38,20 @@ class TestHtmlBeautifierIntegration < Test::Unit::TestCase
       <hr />
       <% end %>
       </div>
+      <table>
+      <colgroup>
+      <col style="width: 50%;">
+      <col style="width: 50%;">
+      </colgroup>
+      <tbody>
+      <tr>
+      <td>First column</td>
+      </tr>
+      <tr>
+      <td>Second column</td>
+      </tr>
+      </tbody>
+      </table>
       </body>
       </html>
     ))
@@ -74,6 +88,20 @@ class TestHtmlBeautifierIntegration < Test::Unit::TestCase
               <hr />
             <% end %>
           </div>
+          <table>
+            <colgroup>
+              <col style="width: 50%;">
+              <col style="width: 50%;">
+            </colgroup>
+            <tbody>
+              <tr>
+                <td>First column</td>
+              </tr>
+              <tr>
+                <td>Second column</td>
+              </tr>
+            </tbody>
+          </table>
         </body>
       </html>
     ))

--- a/test/test_html_beautifier_regression.rb
+++ b/test/test_html_beautifier_regression.rb
@@ -283,4 +283,13 @@ class HtmlBeautifierRegressionTest < Test::Unit::TestCase
     assert_beautifies source, source
   end
 
+  def test_should_not_parse_colgroup_as_standalone
+    source = code(%q(
+    <colgroup>
+      <col style="width: 50%;">
+    </colgroup>
+    ))
+    assert_beautifies source, source
+  end
+
 end


### PR DESCRIPTION
HTML parser matches `colgroup` as a void element and then throws _RuntimeError: Outdented too far on line X_. The problem is in [html_parser.rb:29](https://github.com/threedaymonk/htmlbeautifier/blob/master/lib/htmlbeautifier/html_parser.rb#L29) – see [online example](http://rubular.com/r/1YMghmeMa9).

I’ve fixed this issue and added regression and integration tests.
