### PR TITLE
Properly handle script tags containing only whitespace.

### DIFF
--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -66,7 +66,7 @@ module HtmlBeautifier
 
     def foreign_block(opening, code, closing)
       emit opening
-      unless code.empty?
+      unless code.empty? || code.match(/\A\s+\z/)
         indent
 
         lines = code.split(/\n/)
@@ -141,4 +141,3 @@ module HtmlBeautifier
     end
   end
 end
-

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -90,6 +90,12 @@ describe HtmlBeautifier do
     expect(described_class.beautify(source)).to eq(source)
   end
 
+  it 'removes whitespace from script tags containing only whitespace' do
+    source   = %Q(<script>\n</script>)
+    expected = %Q(<script></script>)
+    expect(described_class.beautify(source)).to eq(expected)
+  end
+
   it 'ignores case of <script> tag' do
     source = code(%q(
       <SCRIPT>


### PR DESCRIPTION
My guess is most people would prefer to leave a single newline if there was at least one newline between the script tags.  The only reason I chose to leave nothing was because it was simpler.

Please note that this change also defines the behavior of style tags containing only whitespace as well.