### PR TITLE
Indent after `until` and `for` without optional `do` keyword.

### DIFF
--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -4,7 +4,7 @@ module HtmlBeautifier
   class Builder
 
     RUBY_INDENT  =
-      %r{ ^ ( if | unless | while | begin | elsif | else )\b
+      %r{ ^ ( if | unless | while | begin | elsif | else | until | for )\b
         | \b ( do | \{ ) ( \s* \| [^\|]+ \| )? $
         }x
     RUBY_OUTDENT =

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -380,4 +380,29 @@ describe HtmlBeautifier do
     ))
     expect(described_class.beautify(source)).to eq(expected)
   end
+  it 'indents after control expressions without optional `do` keyword' do
+    source = code(%q(
+      <% for value in list %>
+      Lorem ipsum
+      <% end %>
+      <% until something %>
+      Lorem ipsum
+      <% end %>
+      <% while something_else %>
+      Lorem ipsum
+      <% end %>
+    ))
+    expected = code(%q(
+      <% for value in list %>
+        Lorem ipsum
+      <% end %>
+      <% until something %>
+        Lorem ipsum
+      <% end %>
+      <% while something_else %>
+        Lorem ipsum
+      <% end %>
+    ))
+    expect(described_class.beautify(source)).to eq(expected)
+  end
 end


### PR DESCRIPTION
I didn't realize `do` was optional on these statements until I found this bug.