### PR TITLE
Version 1.2.0 Add support for Liquid syntax

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+== 1.2.0 (2016-03-09)
+* Add support for Liquid (http://liquidmarkup.org) syntax
+
 == 1.1.1 (2015-07-27)
 * Indent after 'until' and 'for'.
 * Do not modify the content of <textarea>.

--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -1,5 +1,6 @@
 require "htmlbeautifier/parser"
 require "htmlbeautifier/ruby_indenter"
+require "htmlbeautifier/liquid_indenter"
 
 module HtmlBeautifier
   class Builder
@@ -18,6 +19,7 @@ module HtmlBeautifier
       @ie_cc_levels = []
       @output = output
       @embedded_indenter = RubyIndenter.new
+      @liquid_indenter = LiquidIndenter.new
     end
 
   private
@@ -52,6 +54,13 @@ module HtmlBeautifier
       outdent if @embedded_indenter.outdent?(lines)
       emit opening, code, closing
       indent if @embedded_indenter.indent?(lines)
+    end
+
+    def liquid(opening, code, closing)
+      lines = code.split(%r{\n}).map(&:strip)
+      outdent if @liquid_indenter.outdent?(lines)
+      emit opening, code, closing
+      indent if @liquid_indenter.indent?(lines)
     end
 
     def foreign_block(opening, code, closing)

--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -17,6 +17,10 @@ module HtmlBeautifier
     MAPPINGS = [
       [%r{(<%-?=?)(.*?)(-?%>)}om,
        :embed],
+      [%r{(\{%-?)(.*?)(-?%\})}om,
+       :liquid],
+      [%r{(\{\{-?)(.*?)(-?\}\})}om,
+       :liquid],
       [%r{<!--\[.*?\]>}om,
        :open_ie_cc],
       [%r{<!\[.*?\]-->}om,

--- a/lib/htmlbeautifier/liquid_indenter.rb
+++ b/lib/htmlbeautifier/liquid_indenter.rb
@@ -1,0 +1,22 @@
+module HtmlBeautifier
+  class LiquidIndenter
+    LIQUID_INDENT_KEYWORDS =
+      %w[if elsif else unless for comment capture raw case when]
+    LIQUID_OUTDENT_KEYWORDS =
+      %w[elsif else endif endunless endfor endcomment endcapture endraw
+          endcase]
+    LIQUID_INDENT  = %r{
+      ^ ( #{LIQUID_INDENT_KEYWORDS.join("|")} )\b
+      | \b ( do | \{ ) ( \s* \| [^\|]+ \| )? $
+    }xo
+    LIQUID_OUTDENT = %r{ ^ ( #{LIQUID_OUTDENT_KEYWORDS.join("|")} | \} ) \b }xo
+
+    def outdent?(lines)
+      lines.first =~ LIQUID_OUTDENT
+    end
+
+    def indent?(lines)
+      lines.last =~ LIQUID_INDENT
+    end
+  end
+end

--- a/lib/htmlbeautifier/liquid_indenter.rb
+++ b/lib/htmlbeautifier/liquid_indenter.rb
@@ -4,7 +4,7 @@ module HtmlBeautifier
       %w[if elsif else unless for comment capture raw case when]
     LIQUID_OUTDENT_KEYWORDS =
       %w[elsif else endif endunless endfor endcomment endcapture endraw
-          endcase]
+         endcase]
     LIQUID_INDENT  = %r{
       ^ ( #{LIQUID_INDENT_KEYWORDS.join("|")} )\b
       | \b ( do | \{ ) ( \s* \| [^\|]+ \| )? $

--- a/lib/htmlbeautifier/version.rb
+++ b/lib/htmlbeautifier/version.rb
@@ -1,8 +1,8 @@
 module HtmlBeautifier #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 1
-    MINOR = 1
-    TINY  = 1
+    MINOR = 2
+    TINY  = 0
 
     STRING = [MAJOR, MINOR, TINY].join(".")
   end

--- a/spec/documents_spec.rb
+++ b/spec/documents_spec.rb
@@ -42,6 +42,10 @@ describe HtmlBeautifier do
       <tbody>
       <tr><td>First column</td></tr><tr>
       <td>Second column</td></tr>
+      {% if x == y %}
+      <tr><td>{{ third_column }}</td></tr>{% else %}<tr>
+      <td>{{ fourth_column }}</td></tr>
+      {% endif %}
       </tbody>
       </table>
       </body>
@@ -92,6 +96,15 @@ describe HtmlBeautifier do
               <tr>
                 <td>Second column</td>
               </tr>
+              {% if x == y %}
+                <tr>
+                  <td>{{ third_column }}</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td>{{ fourth_column }}</td>
+                </tr>
+              {% endif %}
             </tbody>
           </table>
         </body>


### PR DESCRIPTION
This pull request adds support for the Liquid (https://github.com/Shopify/liquid) syntax. It is very close to erb with only a slightly different opening/closing tag regex and indent/outdent keywords.

I got errors running tests on the master branch of the original project so instead I've tested on numerous ruby/liquid/html files, as well as the code in the document_spec.rb file and results pass :+1:

I cleaned up 3 of 4 Rubocop violations, but the last one is not possible without larger refactoring: `Class has too many lines`. It went from 99 to 107 lines.

I know this may not be something you want to add in the core project, but I thought I'd send upstream just in case ;)