### PR TITLE
Allow general self-closing tags

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -35,6 +35,8 @@ module HtmlBeautifier
        :preformatted_block],
       [%r{<#{HTML_VOID_ELEMENTS}(?: #{ELEMENT_CONTENT})?/?>}om,
        :standalone_element],
+      [%r{<\w+(?: #{ELEMENT_CONTENT})?/>}om,
+       :standalone_element],
       [%r{</#{HTML_BLOCK_ELEMENTS}>}om,
        :close_block_element],
       [%r{<#{HTML_BLOCK_ELEMENTS}(?: #{ELEMENT_CONTENT})?>}om,

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -421,4 +421,34 @@ describe HtmlBeautifier do
     END
     expect(described_class.beautify(source)).to eq(expected)
   end
+
+  it "indents general self-closing tags" do
+    source = code <<-END
+      <div>
+      <svg>
+      <path d="M150 0 L75 200 L225 200 Z" />
+      <circle cx="50" cy="50" r="40" />
+      </svg>
+      <br>
+      <br/>
+      <p>
+      <foo />
+      </p>
+      </div>
+    END
+    expected = code <<-END
+      <div>
+        <svg>
+          <path d="M150 0 L75 200 L225 200 Z" />
+          <circle cx="50" cy="50" r="40" />
+        </svg>
+        <br>
+        <br/>
+        <p>
+          <foo />
+        </p>
+      </div>
+    END
+    expect(described_class.beautify(source)).to eq(expected)
+  end
 end


### PR DESCRIPTION
In some cases, we might have html code embedded with svg code like:

``` html
<html>
  <body>
    <svg>
      <path fill="..." />
      <path fill="..." />
    </svg>
  </body>
</html>
```

As the <path> tag belongs to svg specification, it will not be recognized as `standalone_element` but `open_element`, causing the following html tags to indent incorrectly.

Ending with `/>` can guarantee that the tag is a self-closing tag. Therefore I think we can recognize these tags as `standalone_element` regardless of their names.
