### PR TITLE
Add preserve empty lines option

### DIFF
--- a/bin/htmlbeautifier
+++ b/bin/htmlbeautifier
@@ -51,6 +51,12 @@ END
     options[:stop_on_errors] = num
   end
   opts.on(
+    "-p", "--preserve-empty-lines NUMBER", Integer,
+    "Set number of empty lines in a row to preserve (default 0)"
+  ) do |num|
+    options[:preserve_empty_lines] = num
+  end
+  opts.on(
     "-h", "--help",
     "Display this help message and exit"
   ) do

--- a/lib/htmlbeautifier.rb
+++ b/lib/htmlbeautifier.rb
@@ -15,6 +15,8 @@ module HtmlBeautifier
   # is false, i.e. continue to process the rest of the document.
   # initial_level - The entire output will be indented by this number of steps.
   # Default is 0.
+  # preserve_empty_lines - an integer for the number of empty lines to allow
+  # in a row.
   #
   def self.beautify(html, options = {})
     if options[:tab_stops]

--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -124,7 +124,7 @@ module HtmlBeautifier
     end
 
     def new_lines(*content)
-      empty_lines = content.first.lines.count - 1
+      empty_lines = content.first.scan(%r{\n}).count - 1
       empty_lines = [empty_lines, @preserve_empty_lines].min
       @output << "\n" * empty_lines
       new_line

--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -6,7 +6,8 @@ module HtmlBeautifier
     DEFAULT_OPTIONS = {
       indent: "  ",
       initial_level: 0,
-      stop_on_errors: false
+      stop_on_errors: false,
+      preserve_empty_lines: 0
     }
 
     def initialize(output, options = {})
@@ -14,6 +15,7 @@ module HtmlBeautifier
       @tab = options[:indent]
       @stop_on_errors = options[:stop_on_errors]
       @level = options[:initial_level]
+      @preserve_empty_lines = options[:preserve_empty_lines]
       @new_line = false
       @empty = true
       @ie_cc_levels = []
@@ -45,7 +47,7 @@ module HtmlBeautifier
       @empty = false
     end
 
-    def new_line(*)
+    def new_line
       @new_line = true
     end
 
@@ -119,6 +121,13 @@ module HtmlBeautifier
       emit e
       @ie_cc_levels.push @level
       indent
+    end
+
+    def new_lines(*content)
+      empty_lines = content.first.lines.count - 1
+      empty_lines = [empty_lines, @preserve_empty_lines].min
+      @output << "\n" * empty_lines
+      new_line
     end
 
     def text(t)

--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -122,8 +122,7 @@ module HtmlBeautifier
     end
 
     def text(t)
-      emit t.chomp
-      new_line if t.end_with?("\n")
+      emit t
     end
   end
 end

--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -45,8 +45,8 @@ module HtmlBeautifier
        :close_element],
       [%r{<#{ELEMENT_CONTENT}>}om,
        :open_element],
-      [%r{\s*\r?\n\s*}om,
-       :new_line],
+      [%r{(\s*\r?\n\s*)+}om,
+       :new_lines],
       [%r{[^<\n]+},
        :text]]
 

--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -47,7 +47,7 @@ module HtmlBeautifier
        :open_element],
       [%r{\s*\r?\n\s*}om,
        :new_line],
-      [%r{[^<]+},
+      [%r{[^<\n]+},
        :text]]
 
     def initialize

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -534,6 +534,25 @@ describe HtmlBeautifier do
       END
       expect(described_class.beautify(source, preserve_empty_lines: 1)).to eq(source)
     end
+
+    it "does not indent empty lines" do
+      source = code <<-END
+        <div>
+          Ipsum
+
+
+          <p>dolor</p>
+        </div>
+      END
+      expected = code <<-END
+        <div>
+          Ipsum
+
+          <p>dolor</p>
+        </div>
+      END
+      expect(described_class.beautify(source, preserve_empty_lines: 1)).to eq(expected)
+    end
   end
 
   context "when preserve_empty_lines is 2" do

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -451,4 +451,24 @@ describe HtmlBeautifier do
     END
     expect(described_class.beautify(source)).to eq(expected)
   end
+
+  it "removes excess indentation on next line after text" do
+    source = code <<-END
+      Lorem ipsum
+                      <br>
+      Lorem ipsum
+                      <em>
+        Lorem ipsum
+                      </em>
+    END
+    expected = code <<-END
+      Lorem ipsum
+      <br>
+      Lorem ipsum
+      <em>
+        Lorem ipsum
+      </em>
+    END
+    expect(described_class.beautify(source)).to eq(expected)
+  end
 end

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -489,4 +489,58 @@ describe HtmlBeautifier do
     END
     expect(described_class.beautify(source)).to eq(expected)
   end
+
+  context "when preserve_empty_lines is 0" do
+    it "removes all empty lines" do
+      source = code <<-END
+        <h1>Lorem</h1>
+
+
+
+        <p>Ipsum</p>
+      END
+      expected = code <<-END
+        <h1>Lorem</h1>
+        <p>Ipsum</p>
+      END
+      expect(described_class.beautify(source, preserve_empty_lines: 0)).to eq(expected)
+    end
+  end
+
+  context "when preserve_empty_lines is 1" do
+    it "removes all empty lines but 1" do
+      source = code <<-END
+        <h1>Lorem</h1>
+
+
+
+        <p>Ipsum</p>
+      END
+      expected = code <<-END
+        <h1>Lorem</h1>
+
+        <p>Ipsum</p>
+      END
+      expect(described_class.beautify(source, preserve_empty_lines: 1)).to eq(expected)
+    end
+  end
+
+  context "when preserve_empty_lines is 2" do
+    it "removes all empty lines but 2" do
+      source = code <<-END
+        <h1>Lorem</h1>
+
+
+
+        <p>Ipsum</p>
+      END
+      expected = code <<-END
+        <h1>Lorem</h1>
+
+
+        <p>Ipsum</p>
+      END
+      expect(described_class.beautify(source, preserve_empty_lines: 2)).to eq(expected)
+    end
+  end
 end

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -471,4 +471,22 @@ describe HtmlBeautifier do
     END
     expect(described_class.beautify(source)).to eq(expected)
   end
+
+  it "indents subsequent lines of multiline text" do
+    source = code <<-END
+      <p>
+      Lorem
+      Lorem
+      Lorem
+      </p>
+    END
+    expected = code <<-END
+      <p>
+        Lorem
+        Lorem
+        Lorem
+      </p>
+    END
+    expect(described_class.beautify(source)).to eq(expected)
+  end
 end

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -523,6 +523,17 @@ describe HtmlBeautifier do
       END
       expect(described_class.beautify(source, preserve_empty_lines: 1)).to eq(expected)
     end
+
+    it "does not add empty lines" do
+      source = code <<-END
+        <h1>Lorem</h1>
+        <div>
+          Ipsum
+          <p>dolor</p>
+        </div>
+      END
+      expect(described_class.beautify(source, preserve_empty_lines: 1)).to eq(source)
+    end
   end
 
   context "when preserve_empty_lines is 2" do

--- a/spec/executable_spec.rb
+++ b/spec/executable_spec.rb
@@ -108,4 +108,15 @@ describe "bin/htmlbeautifier" do
 
     expect(status).to be_falsey
   end
+
+  it "allows a configurable number of empty lines in a row" do
+    input = "<h1>foo</h1>\n\n\n\n\n<p>bar</p>\n"
+    expected = "<h1>foo</h1>\n\n\n<p>bar</p>\n"
+    path = path_to("tmp", "in-place.html")
+    write path, input
+
+    system "%s --preserve-empty-lines=2 %s" % [command, escape(path)]
+
+    expect(read(path)).to eq(expected)
+  end
 end


### PR DESCRIPTION
I took a stab at [Could you make an option to let one empty row when there are multiple empty rows? #5](https://github.com/threedaymonk/htmlbeautifier/issues/5).

This is branched off of #41 because it helped fix [this test](https://github.com/mkozono/htmlbeautifier/commit/d1b718d7f75f06c0f136643c362cc44513746e66) in this PR, so that's why the first three commits seem unrelated. I can rebase this branch onto master if #41 gets merged.

**Side notes**
* I also got this to work with a [separate mapping above new_line](https://github.com/mkozono/htmlbeautifier/compare/mkozono:add-preserve-empty-lines-option...mkozono:add-preserve-empty-lines-with-separate-mapping), [as suggested](https://github.com/threedaymonk/htmlbeautifier/issues/5#issuecomment-266797118), but it turned out to be slightly simpler this way anyway.
* The [test in the last commit](https://github.com/mkozono/htmlbeautifier/commit/249deeb3aec7b6f2af8448a05f0d5dae5254785e) never fails in this PR but I thought I'd add it since it catches a bug I created in my other implementation, so it may make a future refactor a little safer.