### PR TITLE
Fix foreign block indentation issue

### DIFF
--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -65,23 +65,27 @@ module HtmlBeautifier
     end
 
     def emit_reindented_block_content(code)
-      lines = code.split(%r{\n})
-      indentation = ""
-      lines.each do |line|
-        if !line.strip.empty?
-          indentation = line[%r{^\s+}]
-          break
-        end
-      end
       lines = code.strip.split(%r{\n})
+      indentation = calc_foreign_block_indentation code
 
       indent
       new_line
       lines.each do |line|
-        emit line.rstrip.sub(/^#{indentation}/, "")
+        emit line.rstrip.sub(%r{^#{indentation}}, "")
         new_line
       end
       outdent
+    end
+
+    def calc_foreign_block_indentation(code)
+      lines = code.split(%r{\n})
+      indentation = ""
+      lines.each do |line|
+        unless line.strip.empty?
+          indentation = line[%r{^\s+}]
+          return indentation
+        end
+      end
     end
 
     def preformatted_block(opening, content, closing)

--- a/lib/htmlbeautifier/builder.rb
+++ b/lib/htmlbeautifier/builder.rb
@@ -65,13 +65,20 @@ module HtmlBeautifier
     end
 
     def emit_reindented_block_content(code)
+      lines = code.split(%r{\n})
+      indentation = ""
+      lines.each do |line|
+        if !line.strip.empty?
+          indentation = line[%r{^\s+}]
+          break
+        end
+      end
       lines = code.strip.split(%r{\n})
-      indentation = lines.first[%r{^\s+}]
 
       indent
       new_line
       lines.each do |line|
-        emit line.rstrip.sub(%r{^#{indentation}}, "")
+        emit line.rstrip.sub(/^#{indentation}/, "")
         new_line
       end
       outdent

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -63,6 +63,54 @@ describe HtmlBeautifier do
     expect(described_class.beautify(source)).to eq(expected)
   end
 
+  it "indents only the first line of code inside <script> or <style> and retains the other lines' indents relative to the first line" do
+    source = code <<-END
+      <script>
+        function(f) {
+            g();
+            return 42;
+        }
+      </script>
+      <style>
+                    .foo{ margin: 0; }
+                    .bar{
+                      padding: 0;
+                      margin: 0;
+                    }
+      </style>
+      <style>
+        .foo{ margin: 0; }
+                    .bar{
+                      padding: 0;
+                      margin: 0;
+                    }
+      </style>
+    END
+    expected = code <<-END
+      <script>
+        function(f) {
+            g();
+            return 42;
+        }
+      </script>
+      <style>
+        .foo{ margin: 0; }
+        .bar{
+          padding: 0;
+          margin: 0;
+        }
+      </style>
+      <style>
+        .foo{ margin: 0; }
+                    .bar{
+                      padding: 0;
+                      margin: 0;
+                    }
+      </style>
+    END
+    expect(described_class.beautify(source)).to eq(expected)
+  end
+
   it "trims blank lines around scripts" do
     source = code <<-END
       <script>


### PR DESCRIPTION
The emit_reindented_block_content function was adding extra indents to
line numbers > 1 when passed code which is already pre-indented. This
causes the beautifier to actually add messy indentation to well indented
foreign block code with each run. This fix resolves that problem. Unit tests
added.

_**Screenshots of the problem**_
**Before Beautifying**
![pre-beautify](https://cloud.githubusercontent.com/assets/12694661/25700043/6e8912f8-30e3-11e7-8bec-e799cecd2646.png)

**After running beautify once**
![post-beautify](https://cloud.githubusercontent.com/assets/12694661/25700041/6e7aab14-30e3-11e7-8120-d16d5fbe4bf8.png)

**After running beautify ~4 times**
_(happens when code editor is set to use htmlbeautifier on save)_ 
![post-4-beautifies](https://cloud.githubusercontent.com/assets/12694661/25700042/6e7bcc88-30e3-11e7-80cd-66f1fc087e26.png)


