### PR TITLE
Support for version option

### DIFF
--- a/bin/htmlbeautifier
+++ b/bin/htmlbeautifier
@@ -57,6 +57,13 @@ END
     options[:keep_blank_lines] = num
   end
   opts.on(
+    "-v", "--version",
+    "Display version and exit"
+  ) do
+    puts HtmlBeautifier::VERSION::STRING
+    exit
+  end
+  opts.on(
     "-h", "--help",
     "Display this help message and exit"
   ) do


### PR DESCRIPTION
Support for version option

```console
$ htmlbeautifier -v
1.3.1

$ htmlbeautifier --version
1.3.1

$ htmlbeautifier -h

.......
    -b, --keep-blank-lines NUMBER    Set number of consecutive blank lines
    -v, --version                    Display version and exit
    -h, --help                       Display this help message and exit
```