### PR TITLE
fix: add hyphen to standalone_element pattern

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -45,7 +45,7 @@ module HtmlBeautifier
        :close_element],
       [%r{<#{ELEMENT_CONTENT}[^/]>}om,
        :open_element],
-      [%r{<\w+(?: #{ELEMENT_CONTENT})?/>}om,
+      [%r{<[\w\-]+(?: #{ELEMENT_CONTENT})?/>}om,
        :standalone_element],
       [%r{(\s*\r?\n\s*)+}om,
        :new_lines],

--- a/spec/documents_spec.rb
+++ b/spec/documents_spec.rb
@@ -46,6 +46,7 @@ describe HtmlBeautifier do
       <td>Second column</td></tr>
       </tbody>
       </table>
+      <custom-tag attr1="" />
       </body>
       </html>
     ERB
@@ -96,6 +97,7 @@ describe HtmlBeautifier do
               </tr>
             </tbody>
           </table>
+          <custom-tag attr1="" />
         </body>
       </html>
     ERB


### PR DESCRIPTION
Thanks for the useful gem!

Tags containing hyphens, which were fine in v1.3.1, will cause errors when trying to format them in v1.4.0.

```
$echo "<custom-tag />" | bundle exec ./bin/htmlbeautifier
bundler: failed to load command: ./bin/htmlbeautifier (./bin/htmlbeautifier)
RuntimeError: Error parsing standard input: Unmatched sequence on line 1
  /home/fukata/dev/src/github.com/fukata/htmlbeautifier/bin/htmlbeautifier:12:in `rescue in beautify'
  /home/fukata/dev/src/github.com/fukata/htmlbeautifier/bin/htmlbeautifier:9:in `beautify'
  /home/fukata/dev/src/github.com/fukata/htmlbeautifier/bin/htmlbeautifier:114:in `<top (required)>'
```

Thank you