### PR TITLE
Add support for <details> with Boolean attribute handled by ERB

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -10,10 +10,11 @@ module HtmlBeautifier
       link | meta | param | source | track | wbr
     )}mix
     HTML_BLOCK_ELEMENTS = %r{(?:
-      address | article | aside | audio | blockquote | canvas | dd | dir | div |
-      dl | dt | fieldset | figcaption | figure | footer | form | h1 | h2 | h3 |
-      h4 | h5 | h6 | header | hr | li | menu | noframes | noscript | ol | p |
-      pre | section | table | tbody | td | tfoot | th | thead | tr | ul | video
+      address | article | aside | audio | blockquote | canvas | dd | details |
+      dir | div | dl | dt | fieldset | figcaption | figure | footer | form |
+      h1 | h2 | h3 | h4 | h5 | h6 | header | hr | li | menu | noframes |
+      noscript | ol | p | pre | section | table | tbody | td | tfoot | th |
+      thead | tr | ul | video
     )}mix
 
     MAPPINGS = [

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -331,6 +331,26 @@ describe HtmlBeautifier do
     expect(described_class.beautify(source)).to eq(expected)
   end
 
+  it "stays indented within <details> with Boolean attribute handled by ERB" do
+    source = code <<~ERB
+      <details <%= "open" if opened %>>
+        <summary>Hello</summary>
+        <div>
+          <table>
+            <% items.each do |item| %>
+              <tr>
+                <td>
+                  <code><%= item %></code>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </details>
+    ERB
+    expect(described_class.beautify(source)).to eq(source)
+  end
+
   it "does not indent after comments" do
     source = code <<~HTML
       <!-- This is a comment -->


### PR DESCRIPTION
**Description**
There is a indentation issue with the [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) element and its [`open`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attr-open) Boolean attribute when the `open` attribute logic is managed via ERB .

<img width="1104" alt="Screen Shot 2022-03-24 at 5 56 44 PM" src="https://user-images.githubusercontent.com/232621/160034014-b80948cf-f6a7-4f2e-bddf-d1f1fa02f6e5.png">

**Fix**
Add `<details>` to the list of HTML block elements in the HTML parser.

