### PR TITLE
remove relative_path_from call

### DIFF
--- a/bin/htmlbeautifier
+++ b/bin/htmlbeautifier
@@ -101,12 +101,9 @@ if ARGV.any?
     end
   end
   unless failures.empty?
-    relative_paths = failures.map { |path|
-      Pathname.new(path).relative_path_from Dir.pwd
-    }
     $stderr.puts [
       "Lint failed - files would be modified:",
-      *relative_paths
+      *failures
     ].join("\n")
     exit 1
   end

--- a/spec/executable_spec.rb
+++ b/spec/executable_spec.rb
@@ -66,11 +66,13 @@ describe "bin/htmlbeautifier" do
     bad_path = path_to("tmp", "bad.html")
     write(bad_path, bad_input)
 
-    expected_message = "Lint failed - files would be modified:\ntmp/bad.html\n"
+    expected_message = "Lint failed - files would be modified:\n<redacted>/tmp/bad.html\n"
 
     _stdout, stderr, status = Open3.capture3(
       "%s %s %s --lint-only" % [command, escape(good_path), escape(bad_path)]
     )
+
+    stderr.sub!(%r{/.*tmp/}, "<redacted>/tmp/")
 
     expect(status.exitstatus).to eq(1)
     expect(stderr).to eq(expected_message)


### PR DESCRIPTION
resolves https://github.com/threedaymonk/htmlbeautifier/issues/65

When originally implemented, the `relative_path_from Dir.pwd` was purely to keep the assertion results consistent across systems. The `path_to` helper in the specs reference absolute paths, so instead I've redacted the path in the spec.

The actual `bin/htmlbeautifier` should not be coercing the path into a relative one. This change will give more consistent output to the user. If a relative path is provided, its failure message will be relative. If an absolute path is provided, its failure message will be absolute.