### PR TITLE
Indent with javascript tag

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -18,6 +18,8 @@ module HtmlBeautifier
     )}mix
 
     MAPPINGS = [
+      [%r{(<%-?=\s*javascript_tag.+-?%>)(.*?)(<%-?=?\s*end\s*-?%>)}om,
+       :foreign_block],
       [%r{(<%-?=?)(.*?)(-?%>)}om,
        :embed],
       [%r{<!--\[.*?\]>}om,

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -65,6 +65,26 @@ describe HtmlBeautifier do
     expect(described_class.beautify(source)).to eq(expected)
   end
 
+  it "indents within <script>" do
+    source = code <<~HTML
+      <%= javascript_tag(nonce: true) do -%>
+      function(f) {
+          g();
+          return 42;
+      }
+      <% end -%>
+    HTML
+    expected = code <<~HTML
+      <%= javascript_tag(nonce: true) do -%>
+        function(f) {
+            g();
+            return 42;
+        }
+      <% end -%>
+    HTML
+    expect(described_class.beautify(source)).to eq(expected)
+  end
+
   it "does not indent blank lines in scripts" do
     source   = "<script>\n  function(f) {\n\n  }\n</script>"
     expected = "<script>\n  function(f) {\n\n  }\n</script>"


### PR DESCRIPTION
allows `<%= javascript_tag %>...<%end>` to behave like `<script>...</script>`

I haven't read enough of the whole library to understand the consequences of this PR! Consider this as much a "feature request / issue" as a PR. 

But was easy enough to hack it together so made a PR. 

Thanks for your wonderful, relatively lightweight gem.