### PR TITLE
Add example to the input and output contents of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ htmlbeautifier file1 [file2 ...]
 or to operate on standard input and output:
 
 ``` sh
-$ htmlbeautifier < input > output
+$ htmlbeautifier < index.erb > index_formatted.erb
 ```
 
 ### In your code


### PR DESCRIPTION
I had difficulty understanding the following section in the README:
```sh
or to operate on standard input and output:

$ htmlbeautifier < input > output
```
The reason was that, I misunderstood that `<input>` should be directly replaced with a file name, and executed the command without the `<>` as shown below:
```sh
htmlbeautifier index.erb index_formatted.erb
```
For clarity, it would be helpful to provide a concrete example in the README like:
```diff
README.md
or to operate on standard input and output:
- $ htmlbeautifier < input > output
+ $ htmlbeautifier < index.erb > index_formatted.erb
```