### PR TITLE
WIP: Fix handling of right angle bracket (`>`) in attributes

### DIFF
--- a/lib/htmlbeautifier/html_parser.rb
+++ b/lib/htmlbeautifier/html_parser.rb
@@ -4,7 +4,7 @@ require "htmlbeautifier/parser"
 
 module HtmlBeautifier
   class HtmlParser < Parser
-    ELEMENT_CONTENT = %r{ (?:<%.*?%>|[^>])* }mx
+    ELEMENT_CONTENT = %r{ (?:<%.*?%>|data-action\s*=\s*"(?:[^"]*?->[^"]*?)"|[^>])* }mx
     HTML_VOID_ELEMENTS = %r{(?:
       area | base | br | col | command | embed | hr | img | input | keygen |
       link | meta | param | source | track | wbr
@@ -44,7 +44,7 @@ module HtmlBeautifier
         :open_block_element],
       [%r{</#{ELEMENT_CONTENT}>}om,
         :close_element],
-      [%r{<#{ELEMENT_CONTENT}[^/]>}om,
+      [%r{<#{ELEMENT_CONTENT}[^/]*?>}om,
         :open_element],
       [%r{<[\w\-]+(?: #{ELEMENT_CONTENT})?/>}om,
         :standalone_element],

--- a/spec/behavior_spec.rb
+++ b/spec/behavior_spec.rb
@@ -623,6 +623,22 @@ describe HtmlBeautifier do
     expect(described_class.beautify(source)).to eq(expected)
   end
 
+  it "does not break for > within an attribute value" do
+    source = code <<~HTML
+      <button data-action="click->hello#greet"
+              type="button">
+        Greet
+      </button>
+    HTML
+    expected = code <<~HTML
+      <button data-action="click->hello#greet"
+              type="button">
+        Greet
+      </button>
+    HTML
+    expect(described_class.beautify(source)).to eq(expected)
+  end
+
   context "when keep_blank_lines is 0" do
     it "removes all blank lines" do
       source = code <<~HTML


### PR DESCRIPTION
This is the fix suggested by @jon-sully in https://github.com/threedaymonk/htmlbeautifier/issues/78#issuecomment-2369219951

It may need further work and verification, so I'm only opening it as a draft for now to allow for discussion.

Also, it breaks one of the current tests: `HtmlBeautifier indents general self-closing tags`